### PR TITLE
Update to Terraform 0.12.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,50 +1,52 @@
 resource "aws_api_gateway_method" "cors_method" {
-  rest_api_id   = "${var.api}"
-  resource_id   = "${var.resource}"
+  rest_api_id   = var.api
+  resource_id   = var.resource
   http_method   = "OPTIONS"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "cors_integration" {
-  rest_api_id = "${var.api}"
-  resource_id = "${var.resource}"
-  http_method = "${aws_api_gateway_method.cors_method.http_method}"
-  type                    = "MOCK"
-  request_templates {
-"application/json" = <<EOF
+  rest_api_id = var.api
+  resource_id = var.resource
+  http_method = aws_api_gateway_method.cors_method.http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" = <<EOF
 { "statusCode": 200 }
 EOF
+
   }
 }
 
 resource "aws_api_gateway_method_response" "cors_method_response" {
-  rest_api_id = "${var.api}"
-  resource_id = "${var.resource}"
-  http_method = "${aws_api_gateway_method.cors_method.http_method}"
+  rest_api_id = var.api
+  resource_id = var.resource
+  http_method = aws_api_gateway_method.cors_method.http_method
 
   status_code = "200"
 
-  response_models {
+  response_models = {
     "application/json" = "Empty"
   }
 
-  response_parameters {
-    "method.response.header.Access-Control-Allow-Headers" = true,
-    "method.response.header.Access-Control-Allow-Methods" = true,
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
     "method.response.header.Access-Control-Allow-Origin" = true
   }
 }
 
 resource "aws_api_gateway_integration_response" "cors_integration_response" {
-  rest_api_id = "${var.api}"
-  resource_id = "${aws_api_gateway_method.cors_method.resource_id}"
-  http_method = "${aws_api_gateway_method.cors_method.http_method}"
+  rest_api_id = var.api
+  resource_id = aws_api_gateway_method.cors_method.resource_id
+  http_method = aws_api_gateway_method.cors_method.http_method
 
-  status_code = "${aws_api_gateway_method_response.cors_method_response.status_code}"
+  status_code = aws_api_gateway_method_response.cors_method_response.status_code
 
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = "'${local.headers}'",
-    "method.response.header.Access-Control-Allow-Methods" = "'${local.methods}'",
+    "method.response.header.Access-Control-Allow-Headers" = "'${local.headers}'"
+    "method.response.header.Access-Control-Allow-Methods" = "'${local.methods}'"
     "method.response.header.Access-Control-Allow-Origin" = "'${var.origin}'"
   }
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -7,30 +7,30 @@ variable "resource" {
 }
 
 variable "methods" {
-  type = "list"
+  type        = list(string)
   description = "List of permitted HTTP methods. OPTIONS is added by default."
 }
 
 variable "origin" {
   description = "Permitted origin"
-  default = "*"
+  default     = "*"
 }
-
 
 variable "headers" {
   description = "List of permitted headers. Default headers are alway present unless discard_default_headers variable is set to true"
-  default = ["Content-Type", "X-Amz-Date", "Authorization", "X-Api-Key", "X-Amz-Security-Token"]
+  default     = ["Content-Type", "X-Amz-Date", "Authorization", "X-Api-Key", "X-Amz-Security-Token"]
 }
 
 variable "discard_default_headers" {
-  default = false
+  default     = false
   description = "When set to true to it discards the default permitted headers and only includes those explicitly defined"
 }
 
 locals {
-  methodOptions = "OPTIONS"
+  methodOptions  = "OPTIONS"
   defaultHeaders = ["Content-Type", "X-Amz-Date", "Authorization", "X-Api-Key", "X-Amz-Security-Token"]
 
-  methods = "${join(",", distinct(concat(var.methods, list(local.methodOptions))))}"
-  headers = "${var.discard_default_headers ? join(",", var.headers) : join(",", distinct(concat(var.headers, local.defaultHeaders)))}"
+  methods = join(",", distinct(concat(var.methods, [local.methodOptions])))
+  headers = var.discard_default_headers ? join(",", var.headers) : join(",", distinct(concat(var.headers, local.defaultHeaders)))
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is the updated code for use with Terraform 0.12.0. It is *NOT* backwards-compatible so I included the `versions.tf` file, that is recommended by Terraform.

As this is a major release with breaking change, please consider setting the version tag to 2.0.0.

What do you think? Any changes to be done or can we merge this?